### PR TITLE
allow text expression for value

### DIFF
--- a/src/complete.js
+++ b/src/complete.js
@@ -1,4 +1,4 @@
-import {parse} from './parse.js';
+import {parseCondition} from './parse.js';
 import {tokenAtPos} from "./tokenize.js";
 
 /**
@@ -15,10 +15,10 @@ function complete(expression, pos, categories, areas) {
         while (parseExpression.length < pos)
             parseExpression += ' ';
         parseExpression = parseExpression.slice(0, pos);
-        // we use a little trick: we run parse() on a manipulated expression where we inserted a dummy character to
+        // we use a little trick: we run parseCondition() on a manipulated expression where we inserted a dummy character to
         // see which completions are offered to us (assuming we typed in something)
         parseExpression += '…';
-        const parseResult = parse(parseExpression, categories, areas);
+        const parseResult = parseCondition(parseExpression, categories, areas);
         const tokenPos = tokenAtPos(parseExpression, pos);
 
         // in case the expression has an error at a position that is parsed before our position we return no suggestions
@@ -43,7 +43,7 @@ function complete(expression, pos, categories, areas) {
         // special cases (and this is actually similar to the situation where we are at the end of the expression).
         // this is quite messy, but relying on the tests for now...
         const modifiedTokenPos = tokenAtPos(parseExpression, tokenPos.range[0]);
-        const parseResult = parse(parseExpression, categories, areas);
+        const parseResult = parseCondition(parseExpression, categories, areas);
         if (parseResult.range[0] !== modifiedTokenPos.range[0])
             return empty();
         const suggestions = parseResult.completions.filter(c => {

--- a/src/custom_model_editor.js
+++ b/src/custom_model_editor.js
@@ -6,7 +6,7 @@ import "codemirror/addon/hint/show-hint";
 import "codemirror/addon/lint/lint";
 import {validateJson} from "./validate_json";
 import {complete} from "./complete.js";
-import {parse} from "./parse.js";
+import {parseCondition} from "./parse.js";
 import {completeJson} from "./complete_json";
 
 
@@ -127,7 +127,7 @@ class CustomModelEditor {
                 });
                 return;
             }
-            const parseRes = parse(condition.substring(1, condition.length-1), this._categories, areas);
+            const parseRes = parseCondition(condition.substring(1, condition.length-1), this._categories, areas);
             if (parseRes.error !== null) {
                 errors.push({
                     message: parseRes.error,

--- a/src/parse.test.js
+++ b/src/parse.test.js
@@ -1,4 +1,4 @@
-import {parse, parseTokens} from './parse';
+import {parseCondition, parseConditionTokens, parseValue} from './parse';
 
 const categories = {
     "a": {type: 'enum', values: ['a1', 'a2', 'a3']},
@@ -11,15 +11,15 @@ const categories = {
 const areas = ["area1", "area2", "area3"];
 const allowedLefts = Object.keys(categories).concat(areas.map(a => 'in_' + a)).concat(['true', 'false']);
 
-describe("parse", () => {
+describe("parseCondition", () => {
 
     test("empty categories", () => {
-        expect(parseTokens('a == a1', {a: {type: 'enum', values: []}}, []).error)
+        expect(parseConditionTokens('a == a1', {a: {type: 'enum', values: []}}, []).error)
             .toBe(`no values given for enum category a`);
     });
 
     test("no categories", () => {
-        expect(parseTokens('a == a1', {}, []).error)
+        expect(parseConditionTokens('a == a1', {}, []).error)
             .toBe(`unexpected token 'a'`)
     });
 
@@ -123,65 +123,90 @@ describe("parse", () => {
         test_parseTokens_valid(['a', '==', 'a1', '&&', '(', 'b', '==', 'b1', '||', 'a', '!=', 'a1', ')', '||', 'b', '!=', 'b2']);
     });
 
-    test("parse, valid", () => {
-        test_parse_valid('a==a1');
-        test_parse_valid('(a==a1)');
-        test_parse_valid('(a==a1)||(b==b1)');
-        test_parse_valid('(a==a1&&b==b1)');
-        test_parse_valid('((a==a1)||b==b1)');
-        test_parse_valid('(a==a1)||b!=b1')
-        test_parse_valid('a==a1&&((b==b1))');
-        test_parse_valid('( a==a1 ) || b != b1 && ( a==a2 ||\n b!=b1 && (a==a1 || b == b2)) && a == a1');
-        test_parse_valid('num1 > 0.3 && bool1 != true || a == a2 && num2 > 0.5 || bool1 == false');
-        test_parse_valid('num1>0.3 && num2<12 || num1>=0.5 && num2<=1.3');
-        test_parse_valid('num1>0.3 && in_area2 || num2<=1.3');
-        test_parse_valid('num1>0.3 && bool1');
-        test_parse_valid('a != a1 && (bool1 || (bool2 && in_area2))');
-        test_parse_valid('a != a1 && (bool1 != false || (in_area2 && bool2))');
-        test_parse_valid('a != a1 && (bool1 != false || ((in_area1 == false) && bool2))');
+    test("parseCondition, valid", () => {
+        test_parseCondition_valid('a==a1');
+        test_parseCondition_valid('(a==a1)');
+        test_parseCondition_valid('(a==a1)||(b==b1)');
+        test_parseCondition_valid('(a==a1&&b==b1)');
+        test_parseCondition_valid('((a==a1)||b==b1)');
+        test_parseCondition_valid('(a==a1)||b!=b1')
+        test_parseCondition_valid('a==a1&&((b==b1))');
+        test_parseCondition_valid('( a==a1 ) || b != b1 && ( a==a2 ||\n b!=b1 && (a==a1 || b == b2)) && a == a1');
+        test_parseCondition_valid('num1 > 0.3 && bool1 != true || a == a2 && num2 > 0.5 || bool1 == false');
+        test_parseCondition_valid('num1>0.3 && num2<12 || num1>=0.5 && num2<=1.3');
+        test_parseCondition_valid('num1>0.3 && in_area2 || num2<=1.3');
+        test_parseCondition_valid('num1>0.3 && bool1');
+        test_parseCondition_valid('a != a1 && (bool1 || (bool2 && in_area2))');
+        test_parseCondition_valid('a != a1 && (bool1 != false || (in_area2 && bool2))');
+        test_parseCondition_valid('a != a1 && (bool1 != false || ((in_area1 == false) && bool2))');
     });
 
-    test("parse, invalid", () => {
-        test_parse('xyz', `unexpected token 'xyz'`, [0, 3], allowedLefts);
-        test_parse('a==a1( b!=b1', `unexpected token '('`, [5, 6], ['||', '&&']);
-        test_parse('(a==a1)(b!=b2)', `unexpected token '('`, [7, 8], ['||', '&&']);
-        test_parse('((a==&&a1)(b!=b1)', `invalid a: '&&'`, [5, 7], ['a1', 'a2', 'a3']);
-        test_parse('((a!=a1||)))', `unexpected token ')'`, [9, 10], allowedLefts);
-        test_parse('\na\t(||', `invalid operator '('`, [3, 4], ['==', '!=']);
-        test_parse('a== a1(b!=b2||', `unexpected token '('`, [6, 7], ['||', '&&']);
-        test_parse('||', `unexpected token '||'`, [0, 2], allowedLefts);
-        test_parse('a==a1||', `unexpected token '||'`, [5, 7], []);
-        test_parse('a==a1&&(', `empty comparison`, [8, 8], []);
-        test_parse(' (', `empty comparison`, [2, 2], []);
-        test_parse('a == a1 || num1 != b1', `invalid num1: 'b1'`, [19, 21], ['__hint__type a number']);
-        test_parse(`a == a1 || bool2 == 'false'`, `invalid bool2: ''false''`, [20, 27], ['true', 'false']);
-        test_parse(`b != b1 || num2 > 0.7 && bool1 != 'true'`, `invalid bool1: ''true''`, [34, 40], ['true', 'false']);
-        test_parse('a == a2 && b <= b1', `invalid operator '<='`, [13, 15], ['==', '!=']);
-        test_parse('a == a1 || area1', `area names must be prefixed with 'in_'`, [11, 16], ['in_area1', 'in_area2', 'in_area3']);
-        test_parse('a == a1 || area_1', `unexpected token 'area_1'`, [11, 17], allowedLefts);
-        test_parse(' == bool1', `unexpected token '=='`, [1, 3], allowedLefts);
-        test_parse('bool1 != a2', `invalid bool1: 'a2'`, [9, 11], ['true', 'false']);
-        test_parse('in_area1 == tru || a == a1', `invalid in_area1: 'tru'`, [12, 15], ['true', 'false']);
+    test("parseCondition, invalid", () => {
+        test_parseCondition('xyz', `unexpected token 'xyz'`, [0, 3], allowedLefts);
+        test_parseCondition('a==a1( b!=b1', `unexpected token '('`, [5, 6], ['||', '&&']);
+        test_parseCondition('(a==a1)(b!=b2)', `unexpected token '('`, [7, 8], ['||', '&&']);
+        test_parseCondition('((a==&&a1)(b!=b1)', `invalid a: '&&'`, [5, 7], ['a1', 'a2', 'a3']);
+        test_parseCondition('((a!=a1||)))', `unexpected token ')'`, [9, 10], allowedLefts);
+        test_parseCondition('\na\t(||', `invalid operator '('`, [3, 4], ['==', '!=']);
+        test_parseCondition('a== a1(b!=b2||', `unexpected token '('`, [6, 7], ['||', '&&']);
+        test_parseCondition('||', `unexpected token '||'`, [0, 2], allowedLefts);
+        test_parseCondition('a==a1||', `unexpected token '||'`, [5, 7], []);
+        test_parseCondition('a==a1&&(', `empty comparison`, [8, 8], []);
+        test_parseCondition(' (', `empty comparison`, [2, 2], []);
+        test_parseCondition('a == a1 || num1 != b1', `invalid num1: 'b1'`, [19, 21], ['__hint__type a number']);
+        test_parseCondition(`a == a1 || bool2 == 'false'`, `invalid bool2: ''false''`, [20, 27], ['true', 'false']);
+        test_parseCondition(`b != b1 || num2 > 0.7 && bool1 != 'true'`, `invalid bool1: ''true''`, [34, 40], ['true', 'false']);
+        test_parseCondition('a == a2 && b <= b1', `invalid operator '<='`, [13, 15], ['==', '!=']);
+        test_parseCondition('a == a1 || area1', `area names must be prefixed with 'in_'`, [11, 16], ['in_area1', 'in_area2', 'in_area3']);
+        test_parseCondition('a == a1 || area_1', `unexpected token 'area_1'`, [11, 17], allowedLefts);
+        test_parseCondition(' == bool1', `unexpected token '=='`, [1, 3], allowedLefts);
+        test_parseCondition('bool1 != a2', `invalid bool1: 'a2'`, [9, 11], ['true', 'false']);
+        test_parseCondition('in_area1 == tru || a == a1', `invalid in_area1: 'tru'`, [12, 15], ['true', 'false']);
     });
 
-    function test_parse_valid(expression) {
-        const res = parse(expression, categories, areas);
-        check(test_parse_valid, res, null, [], []);
+    test("parseValue, valid", () => {
+        test_parseValue_valid('num1');
+        test_parseValue_valid('17');
+        test_parseValue_valid('17*13');
+        test_parseValue_valid('num1+num2');
+        test_parseValue_valid('2 + num2');
+    });
+
+    test("parseValue, invalid", () => {
+        test_parseValue('a1', `unexpected token 'a1'`, [0, 2], []);
+        test_parseValue('num1-a1', `unexpected token 'a1'`, [5, 7], []);
+        // TODO NOW completion is still wrong
+        test_parseValue('num1||num2', `unexpected token '||'`, [4, 6], ['+', '-', '*', '/']);
+    });
+
+    function test_parseCondition_valid(expression) {
+        const res = parseCondition(expression, categories, areas);
+        check(test_parseCondition_valid, res, null, [], []);
     }
 
-    function test_parse(expression, error, range, completions) {
-        const res = parse(expression, categories, areas);
-        check(test_parse, res, error, range, completions);
+    function test_parseCondition(expression, error, range, completions) {
+        const res = parseCondition(expression, categories, areas);
+        check(test_parseCondition, res, error, range, completions);
     }
 
     function test_parseTokens_valid(tokens) {
-        const res = parseTokens(tokens, categories, areas);
+        const res = parseConditionTokens(tokens, categories, areas);
         check(test_parseTokens_valid, res, null, [], []);
     }
 
     function test_parseTokens(tokens, error, range, completions) {
-        const res = parseTokens(tokens, categories, areas);
+        const res = parseConditionTokens(tokens, categories, areas);
         check(test_parseTokens, res, error, range, completions);
+    }
+
+    function test_parseValue_valid(expression) {
+        const res = parseValue(expression, categories, areas);
+        check(test_parseValue_valid, res, null, [], []);
+    }
+
+    function test_parseValue(expression, error, range, completions) {
+        const res = parseValue(expression, categories, areas);
+        check(test_parseValue, res, error, range, completions);
     }
 
     function check(fun, res, error, range, completions) {

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -1,5 +1,5 @@
 /** Symbols used for the tokenization */
-const singleCharSymbols = ['(', ')', '<', '>'];
+const singleCharSymbols = ['(', ')', '<', '>', '+', '-', '*', '/'];
 const doubleCharSymbols = ['||', '&&', '==', '!=', '<=', '>='];
 
 /**
@@ -59,7 +59,7 @@ function tokenize(expression) {
             }
         }
         // we recursively extract one symbol or character at a time and repeat the same function for 
-        // the remaining expression.. we keep track of how many characters we found since the last symbol
+        // the remaining expression. we keep track of how many characters we found since the last symbol
         // or whitespace ('buffer')
         if (isDoubleCharSymbol(expression, pos)) {
             push(pos - buffer, pos);

--- a/src/tokenize.test.js
+++ b/src/tokenize.test.js
@@ -22,6 +22,9 @@ describe("tokenize", () => {
         test_tokenize('ab   xy \n \t zz', ['ab', 'xy', 'zz'], [[0, 2], [5, 7], [12, 14]]);
         test_tokenize('   abc   def\t\n\n', ['abc', 'def'], [[3, 6], [9, 12]]);
         test_tokenize('ab( c)(  (a ) ', ['ab', '(', 'c', ')', '(', '(', 'a', ')'], [[0, 2], [2, 3], [4, 5], [5, 6], [6, 7], [9, 10], [10, 11], [12, 13]]);
+        test_tokenize('ab+c', ['ab', '+', 'c'], [[0, 2], [2, 3], [3, 4]]);
+        test_tokenize('ab / c', ['ab', '/', 'c'], [[0, 2], [3, 4], [5, 6]]);
+
     });
 
     test("get token at position", () => {
@@ -55,6 +58,7 @@ describe("tokenize", () => {
         test_tokenAtPos('  abc== d &&(e != xy(z)', 18, 'xy', [18, 20]);
         test_tokenAtPos('  abc==\n\n\tdef\n&&', 7, null, [7, 10]);
         test_tokenAtPos('  abc==\n\n\tdef\n&&', 12, 'def', [10, 13]);
+        test_tokenAtPos(' abc   * d - 3', 7, '*', [7, 8]);
     });
 
     function test_tokenAtPos(expression, pos, token, range) {

--- a/src/validate_json.test.js
+++ b/src/validate_json.test.js
@@ -182,7 +182,7 @@ describe('validate_json', () => {
         expect(res.conditionRanges).toStrictEqual([[18, 25], [56, 63], [116, 123]]);
     });
 
-    test('speed/priority operator values must be numbers', () => {
+    test('speed/priority operator values must be numbers or value expression', () => {
         test_validate(`{"speed": [{"if": "condition", "multiply_by": []}]}`, [
             `speed[0][multiply_by]: must be a number. given type: array, range: [46, 48]`
         ]);


### PR DESCRIPTION
This change is necessary to merge the [text_value_rhs branch](https://github.com/graphhopper/graphhopper/compare/text_value_rhs) in graphhopper/graphhopper. 

I adapted the parse method (renamed to parseCondition) and introduced a new parseValue, and added some tests for this. So basic expressions like "numeric_ev + numeric_ev2" are now supported. 

Remaining things to do:

 - [ ] the completion part is where I'm unsure on how to properly do that as the handling there is a bit special.
 - [ ] Also allow operation `-`.