### PR TITLE
Allow turn_penalty key in custom model

### DIFF
--- a/src/validate_json.js
+++ b/src/validate_json.js
@@ -1,6 +1,6 @@
 import {parseTree, printParseErrorCode} from "jsonc-parser";
 
-const rootKeys = ['speed', 'priority', 'distance_influence', 'areas'];
+const rootKeys = ['speed', 'priority', 'distance_influence', 'areas', 'turn_penalty'];
 const clauses = ['if', 'else_if', 'else'];
 const operators = ['multiply_by', 'limit_to'];
 const statementKeys = clauses.concat(operators);

--- a/src/validate_json.test.js
+++ b/src/validate_json.test.js
@@ -46,10 +46,10 @@ describe('validate_json', () => {
 
     test('root keys are valid', () => {
         test_validate(`{"abc": "def"}`, [
-            `root: possible keys: ['speed', 'priority', 'distance_influence', 'areas']. given: 'abc', range: [1, 6]`
+            `root: possible keys: ['speed', 'priority', 'distance_influence', 'areas', 'turn_penalty']. given: 'abc', range: [1, 6]`
         ]);
         test_validate(`{"spee": []}`, [
-            `root: possible keys: ['speed', 'priority', 'distance_influence', 'areas']. given: 'spee', range: [1, 7]`
+            `root: possible keys: ['speed', 'priority', 'distance_influence', 'areas', 'turn_penalty']. given: 'spee', range: [1, 7]`
         ]);
     });
 


### PR DESCRIPTION
This change allows using the "turn_penalty" key within custom models - it should no longer be marked as an error.

With the introduction of scriptable turn penalties (see GraphHopper 11.0, https://github.com/graphhopper/graphhopper/pull/3174), turn costs can now be defined more flexibly. This change was not reflected in the custom model editor.

Fixes: 
<img width="600" alt="screenshot" src="https://github.com/user-attachments/assets/183876f8-2614-45b5-aa1f-cb191cacea2f" />


