### PR TITLE
Add operation 'add'

### DIFF
--- a/src/complete_json.js
+++ b/src/complete_json.js
@@ -28,7 +28,7 @@ export function completeJson(content, pos) {
         /^root-object-property\[(speed|priority)]-array\[[0-9]+]-object(-property|-property-key)?$/.test(signatureString)
     ) {
         const clauses = ['"if"', '"else_if"', '"else"'];
-        const operators = ['"limit_to"', '"multiply_by"'];
+        const operators = ['"limit_to"', '"multiply_by"', '"add"'];
         const hasClause = jsonPath.signature.length > 4 && keysAlreadyExistInOtherPairs(jsonPath.path[3].children, jsonPath.path[4], clauses);
         const hasOperator = jsonPath.signature.length > 4 && keysAlreadyExistInOtherPairs(jsonPath.path[3].children, jsonPath.path[4], operators);
         let suggestions = [];

--- a/src/validate_json.js
+++ b/src/validate_json.js
@@ -2,7 +2,7 @@ import {parseTree, printParseErrorCode} from "jsonc-parser";
 
 const rootKeys = ['speed', 'priority', 'distance_influence', 'areas'];
 const clauses = ['if', 'else_if', 'else'];
-const operators = ['multiply_by', 'limit_to'];
+const operators = ['multiply_by', 'limit_to', 'add'];
 const statementKeys = clauses.concat(operators);
 
 let _conditionRanges = [];


### PR DESCRIPTION
This pull requests adds the operation `add` which is supported in GraphHopper since version 11.0 (current stable release).

This missing feature was mentioned in https://github.com/graphhopper/custom-model-editor/pull/7#issuecomment-4236082095